### PR TITLE
Update consulate page link text

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -101,7 +101,7 @@ export default function Home() {
             </div>
             <footer className="card-footer">
               <Link href="/consulates">
-                <a className="card-footer-item">Check consulate wait times</a>
+                <a className="card-footer-item">Check consulate visa issuance rates</a>
               </Link>
             </footer>
           </div>


### PR DESCRIPTION
To match the page's functionality. As far as I can tell, the "Consulate" section does not provide wait times, but only statistics about the number of visas issued per month, per visa, per consulate. So, updating the link text to match the page's functionality.