### PR TITLE
ci: stream the notebooks without the display() shim

### DIFF
--- a/.github/workflows/consulate_update_schedule.yml
+++ b/.github/workflows/consulate_update_schedule.yml
@@ -77,18 +77,15 @@ jobs:
       # The notebooks are converted to scripts and streamed into python instead
       # of being executed with `nbconvert --execute`: output shows up in the job
       # log as it happens, and `::warning::` lines reach GitHub as annotations.
-      #
-      # The notebooks call display(), which is a builtin only inside an IPython
-      # kernel, so the converted script is prefixed with the matching import
-      # (outside IPython, display() prints the object's repr). The brace group
-      # keeps nbconvert as the pipeline's first stage, so pipefail still catches
-      # a failing conversion.
+      # The notebooks import display() from IPython themselves (it is only a
+      # builtin inside a kernel; outside one it prints the object's repr), and
+      # pipefail makes a failing conversion fail the step.
       - name: Run visa-issuances notebook
         run: |
-          { echo 'from IPython.display import display'; poetry run jupyter nbconvert --to script --stdout visa-issuances.ipynb; } | poetry run python -u -
+          poetry run jupyter nbconvert --to script --stdout visa-issuances.ipynb | poetry run python -u -
       - name: Run baselines notebook
         run: |
-          { echo 'from IPython.display import display'; poetry run jupyter nbconvert --to script --stdout baselines.ipynb; } | poetry run python -u -
+          poetry run jupyter nbconvert --to script --stdout baselines.ipynb | poetry run python -u -
 
       - name: Save poetry virtualenv
         if: always() && steps.cache-poetry.outputs.cache-hit != 'true'


### PR DESCRIPTION
The shim echoed `from IPython.display import display` in front of the converted script, but both notebooks start with `from __future__ import annotations`, which must be the first statement — so the consulates job failed with a SyntaxError on its first run after #389. The notebooks already import `display` themselves; verified the streamed scripts parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZ8Z3GYZh2nMzWdvEA1kua